### PR TITLE
grammar fixes in some places, added some replacements in others

### DIFF
--- a/docs/1.8.9/dungeon_utilities.md
+++ b/docs/1.8.9/dungeon_utilities.md
@@ -1,8 +1,8 @@
 # DungeonUtilities Alternatives
 DungeonUtilities was an amazing
-mod for Dungeon solvers and map
+ChatTriggers module for Dungeon solvers and map
 display, among other things, but
-is now discontinued by it's
+is now discontinued by its
 creator and he recommends using alternatives.
 
 * Map - [Moulberry's NotEnoughUpdates](https://github.com/Moulberry/NotEnoughUpdates/latest) / [Biscuit's SkyblockAddons](https://github.com/BiscuitDevelopment/SkyblockAddons/releases/latest) / [Syeyoung's DungeonGuide](https://github.com/Dungeons-Guide/Skyblock-Dungeons-Guide/releases/latest) / [Sychic & Lily's Skytils](https://github.com/Skytils/SkytilsMod/releases/latest)
@@ -14,4 +14,5 @@ creator and he recommends using alternatives.
 
 # Contributors
 
+* [RayDeeUx](https://github.com/RayDeeUx)
 * [Zetvue](https://zetvue.carrd.co)

--- a/docs/1.8.9/feather_client.md
+++ b/docs/1.8.9/feather_client.md
@@ -99,7 +99,7 @@ mod authors and it is advised against supporting them.
 * Highlight - [W-OVERFLOW's REDACTION](https://github.com/W-OVERFLOW/REDACTION)
 * Color - [W-OVERFLOW's REDACTION](https://github.com/W-OVERFLOW/REDACTION)
 * Bold - [W-OVERFLOW's REDACTION](https://github.com/W-OVERFLOW/REDACTION)
-* Own Messages - [W-OVERFLOW's Chatting](https://github.com/W-OVERFLOW/Chatting)
+* Own Messages - [W-OVERFLOW's REDACTION](https://github.com/W-OVERFLOW/REDACTION)
 
 ## Performance
 

--- a/docs/1.8.9/feather_client.md
+++ b/docs/1.8.9/feather_client.md
@@ -99,7 +99,7 @@ mod authors and it is advised against supporting them.
 * Highlight - [W-OVERFLOW's REDACTION](https://github.com/W-OVERFLOW/REDACTION)
 * Color - [W-OVERFLOW's REDACTION](https://github.com/W-OVERFLOW/REDACTION)
 * Bold - [W-OVERFLOW's REDACTION](https://github.com/W-OVERFLOW/REDACTION)
-* Own Messages - ?
+* Own Messages - [W-OVERFLOW's Chatting](https://github.com/W-OVERFLOW/Chatting)
 
 ## Performance
 

--- a/docs/1.8.9/hychat.md
+++ b/docs/1.8.9/hychat.md
@@ -1,4 +1,5 @@
 # HyChat Alternatives
+The mod is no longer supported by its developer, Moulberry.
 
 ### Tweaks
 
@@ -19,8 +20,8 @@
 
 ### Appearance
 
-*Text Shadow - ?
-*Tab Text Shadow - ?
+* Text Shadow - ?
+* Tab Text Shadow - ?
 
 ### Screenshot and Copying
 
@@ -37,4 +38,5 @@
 # Contributors
 
 * [GhoulBoi69](https://github.com/GhoulBoii)
+* [RayDeeUx](https://github.com/RayDeeUx)
 * [Zetvue](https://zetvue.carrd.co)

--- a/docs/1.8.9/labymod.md
+++ b/docs/1.8.9/labymod.md
@@ -10,8 +10,8 @@ that you avoid using it if possible.
 
 * Ping in Tablist - [Sk1er's Patcher](https://sk1er.club/mods/patcher)
 * Permission Changes - Irrelevant
-* LabyMod User Indicator - [Sk1er's Essential](https://essential.gg) (indicates Essential instead)
-* Out of Memory Warning - ? (Check F3)
+* LabyMod User Indicator - [Sk1er's Essential](https://essential.gg) (indicates Essential users instead)
+* Out of Memory Warning - ? (Check F3 / [isXander's EvergreenHUD](https://modrinth.com/mod/evergreenhud/versions) for current memory usage)
 
 ### Animations
 
@@ -198,6 +198,7 @@ that you avoid using it if possible.
 * [LlamaLad7](https://github.com/LlamaLad7)
 * [Lizzy](https://github.com/LizzyMaybeDev)
 * [Moiré](https://github.com/moire9)
+* [RayDeeUx](https://github.com/RayDeeUx)
 * [Rayless](https://github.com/UnderscoreRayless)
 * [Solonovamax](https://github.com/solonovamax)
 * [ToggledX](https://twitter.com/ignToggleW)

--- a/docs/1.8.9/lunar_client.md
+++ b/docs/1.8.9/lunar_client.md
@@ -23,7 +23,7 @@
 ### Hypixel Mods
 
 * Auto Friend - [W-OVERFLOW's Hytils Reborn](https://github.com/W-OVERFLOW/Hytils-Reborn/releases/latest)
-* Auto TIP - [Semx11's AutoTip](https://autotip.pro/download)
+* Auto Tip - [Semx11's AutoTip](https://autotip.pro/download)
 * Auto GG - [Sk1er's AutoGG & AntiGG](https://sk1er.club/mods/autogg)
 * Anti GG - [Sk1er's AutoGG & AntiGG](https://sk1er.club/mods/autogg)
 * Auto Who - No longer works on Hypixel
@@ -115,7 +115,7 @@
 * Freelook **(BANNABLE ON HYPIXEL)** - [DJtheRedstoner's Perspective Mod](https://inv.wtf/djperspective)
 * Quickplay - [Buggyfroggy's QuickPlay](https://github.com/QuickplayMod/quickplay/releases/latest)
 * 3D Skin Layers - [tr7zw's 3D Skin Layers](https://www.curseforge.com/minecraft/mc-mods/skin-layers-3d/files/all?filter-game-version=2020709689%3A5806)
-* Better Sounds - [Sk1er's Patcher](https://sk1er.club/mods/patcher) (/patcher sounds)
+* Better Sounds - [Sk1er's Patcher](https://sk1er.club/mods/patcher) (`/patcher sounds`)
 
 ## Settings
 
@@ -146,7 +146,7 @@
 #### Texture Pack Options
 
 * Transparent Background - [Aycy's Resource Pack Manager](https://www.youtube.com/watch?v=OQZFWrrEcYM)
-* Red String - Texture Pack
+* Red String - ? (can be accomplished via a texture pack)
 
 ### Performance
 
@@ -187,6 +187,7 @@
 * [Lizzy](https://github.com/LizzyMaybeDev)
 * [Moiré](https://github.com/moire9)
 * [oyMarcel](https://github.com/oyMarcel)
+* [RayDeeUx](https://github.com/RayDeeUx)
 * [Salmon](https://github.com/Scherso)
 * [Solonovamax](https://github.com/solonovamax)
 * [Wyvest](https://github.com/Wyvest)

--- a/docs/1.8.9/refraction_v4.md
+++ b/docs/1.8.9/refraction_v4.md
@@ -6,7 +6,7 @@
 * [Patcher](https://sk1er.club/mods/patcher)
 * [SkyblockAddons](https://github.com/BiscuitDevelopment/SkyblockAddons/releases/latest)
 * [BlockOverlay](https://hypixel.net/threads/forge-1-8-9-block-overlay-v4-0-3.1417995/)
-* [Scrollable tooltips](https://sk1er.club/mods/text_overflow_scroll)
+* [Scrollable Tooltips](https://sk1er.club/mods/text_overflow_scroll)
 * [AutoGG](https://sk1er.club/mods/autogg)
 * [Levelhead](https://sk1er.club/mods/level_head)
 * [ToggleChat](https://github.com/boomboompower/ToggleChat/releases/)
@@ -25,8 +25,9 @@
     * Spiderfrog's OAM causes many issues with other mods, is bloated, and causes crashes. Sk1er's is more accurate to 1.7 with better compatibility and no bloat.
 * [Powns's ToggleSneak with Lily's SimpleToggleSprint](https://github.com/My-Name-Is-Jeff/SimpleToggleSprint/releases/latest)
     * Powns's ToggleSneak is no longer maintained and has some small issues that Lily's fixes.
-* [Skywars Stats mod with HyStats](https://download2270.mediafire.com/0r5h180odzzg/yx8m6ztaduf5bx8/HyStats-v4.0_%281.8.9%29.jar)
-    * Both made by KAD7, Hystats now supports multiple gamemodes and has much more to offer compared to the discontinued Skywars Stats mod.
+* Skywars Stats mod with **either** [HyStats](https://download2270.mediafire.com/0r5h180odzzg/yx8m6ztaduf5bx8/HyStats-v4.0_%281.8.9%29.jar) **OR** [SimpleStats](https://github.com/mew/simplestats)
+    * KAD7's more recent Hystats now supports multiple gamemodes and has much more to offer compared to the discontinued Skywars Stats mod.
+    * Nora/mew's SimpleStats mod accomplishes similar goals, but is open source.
 
 ## Remove
 
@@ -52,4 +53,5 @@
 * [JackedUp21](https://github.com/JackedUp21)
 * [JitterDev](https://github.com/JitterDev)
 * [MisterCheezeCake](https://github.com/MisterCheezeCake)
+* [RayDeeUx](https://github.com/RayDeeUx)
 * [Wyvest](https://github.com/wyvest)

--- a/docs/1.8.9/skyblock_reinvented.md
+++ b/docs/1.8.9/skyblock_reinvented.md
@@ -12,7 +12,7 @@ to use those other mods instead.
 
 ### Sounds
 
-* Remove Creeper Sounds from Veil - ?
+* Remove Creeper Sounds from Veil - [Sk1er's Patcher](https://sk1er.club/mods/patcher)
 
 ## General
 
@@ -33,11 +33,11 @@ to use those other mods instead.
 
 ### Rendering
 
-* Stop Rendering Players with Customizable Whitelist - ?
+* Stop Rendering Players with Customizable Whitelist - ? ([W-OVERFLOW's Hytils Reborn](https://github.com/W-OVERFLOW/Hytils-Reborn) has a similar feature that consequently removes players, but does not have a whitelist)
 * Stop Rendering Player Armor - ?
-* Create Hitboxes Around your Arrows - F3 + B
-* Show Hitboxes of Special Zealots - F3 + B
-* Show Hitboxes of Drags & Golems - F3 + B
+* Create Hitboxes Around your Arrows - [W-OVERFLOW's REDACTION](https://github.com/W-OVERFLOW/REDACTION)
+* Show Hitboxes of Special Zealots - [W-OVERFLOW's REDACTION](https://github.com/W-OVERFLOW/REDACTION)
+* Show Hitboxes of Drags & Golems - [W-OVERFLOW's REDACTION](https://github.com/W-OVERFLOW/REDACTION)
 * Hide Other People's Arrows - [Sk1er's Patcher](https://sk1er.club/mods/patcher)
 * Stop Power Orb Nametags / Particles from Rendering - ?
 
@@ -149,4 +149,5 @@ to use those other mods instead.
 
 # Contributors
 
+* [RayDeeUx](https://github.com/RayDeeUx)
 * [Rayless](https://github.com/UnderscoreRayless)

--- a/docs/1.8.9/skyblockcatia.md
+++ b/docs/1.8.9/skyblockcatia.md
@@ -39,7 +39,7 @@ if the features you use can be replaced.
 
 * Right Click to Add Party - [Am4nso's MiddleClickParty](https://hypixel.net/threads/forge-1-8-9-middleclickparty-invite-players-to-your-party-by-middle-clicking.3349916/)
 * Sneak to Open Inventory While Fighting Dragon - ?
-* Lobby Player Count - [Rocco's 5Zig Reborn](https://5zigreborn.eu/)
+* Lobby Player Count - [isXander's EvergreenHUD](https://modrinth.com/mod/evergreenhud/versions)
 * Show Obtained Date - [Cow's Cowlection](https://github.com/cow-mc/Cowlection/releases/latest)
 
 ### Global Config
@@ -64,6 +64,7 @@ if the features you use can be replaced.
 * [8KCoffeeWizard](https://github.com/8KCoffeeWizard)
 * [Lisena](https://github.com/lisenaaaa)
 * [MisterCheezeCake](https://github.com/MisterCheezeCake)
+* [RayDeeUx](https://github.com/RayDeeUx)
 * [Rayless](https://github.com/UnderscoreRayless)
 * [Wyvest](https://github.com/Wyvest)
 * [Zetvue](https://zetvue.carrd.co)


### PR DESCRIPTION
* d_utils.md: grammar + technicality
* feather.md: REDACTION's name highlight is very aggressive that it ends up applying to own messages
* hychat.md: fix markdown syntax and add intro sentence
* labymod.md: xander's evergreen has mem display
* lunar.md: grammar, capitalization, markdown syntax
* refrac_v4.md: add mod, reword sentence, fix one capitalization error
* sbreinvented.md: added mods
* sbcatia.md: replace 5zig with xander evergreen—even 5zig reborn has slowly discontinued