### PR TITLE
Fixing BetterHurtCam and ReplayMod

### DIFF
--- a/docs/1.12.2/feather_client.md
+++ b/docs/1.12.2/feather_client.md
@@ -137,7 +137,7 @@ mod authors and it is advised against supporting them.
 
 ## External Mods
 
-* [Replay Mod](https://www.replaymod.com)
+* [Replay Mod](https://modrinth.com/mod/replaymod/versions)
 * [OptiFine](https://optifine.net/adloadx?f=OptiFine_1.12.2_HD_U_G5.jar)
 * [Xaero's Minimap](https://www.curseforge.com/minecraft/mc-mods/xaeros-minimap/files/all?filter-game-version=2020709689%3A6756)
 * [Quickplay](https://hypixel.net/threads/forge-quickplay-v2-0-3-quickly-join-games-on-the-network.1317410/)

--- a/docs/1.8.9/badlion_client.md
+++ b/docs/1.8.9/badlion_client.md
@@ -94,7 +94,7 @@
 * Zoom - [sp614x's OptiFine](https://optifine.net/adloadx?f=preview_OptiFine_1.8.9_HD_U_M6_pre2.jar) / [Sk1er's Patcher](https://sk1er.club/mods/patcher) (tweaks   Optifine's)
 * Emotes - ?
 * Sprays - ?
-* Replay Mod - [Replay Mod](https://www.replaymod.com/download/)
+* Replay Mod - [Replay Mod](https://modrinth.com/mod/replaymod/versions)
 * Schematica Mod - [Lunatrius's Schematica](https://www.curseforge.com/minecraft/mc-mods/schematica/files/2279147/files/all?filter-game-version=2020709689%3A5806)
 * TeamSpeak Mod - ?
 * MumbleLink - [snipingcoward's MumbleLink](https://www.curseforge.com/minecraft/mc-mods/mumblelink/files/2327154/files/all?filter-game-version=2020709689%3A5806)

--- a/docs/1.8.9/feather_client.md
+++ b/docs/1.8.9/feather_client.md
@@ -137,7 +137,7 @@ mod authors and it is advised against supporting them.
 * [Cowlection](https://github.com/cow-mc/Cowlection/releases/latest)
 * [BazaarNotifier](https://github.com/symt/BazaarNotifier/releases/latest)
 * [ResourcePack Manager](https://www.youtube.com/watch?v=OQZFWrrEcYM)
-* [Replay Mod](https://www.replaymod.com)
+* [Replay Mod](https://modrinth.com/mod/replaymod/versions)
 * [OptiFine](https://optifine.net)
 * [Xaero's Minimap](https://www.curseforge.com/minecraft/mc-mods/xaeros-minimap)
 * [Quickplay](https://hypixel.net/threads/forge-quickplay-v2-0-3-quickly-join-games-on-the-network.1317410/)

--- a/docs/1.8.9/lunar_client.md
+++ b/docs/1.8.9/lunar_client.md
@@ -100,14 +100,14 @@
 * Item Physics - [CreativeMD's ItemPhysic Lite](https://www.curseforge.com/minecraft/mc-mods/itemphysic-lite/files/all?filter-game-version=2020709689%3A5806)
 * TNT Timer Mod - [Sk1er's TNT Time](https://sk1er.club/mods/tnttime)
 * Hitbox - [Polyfrost's REDACTION](https://github.com/Polyfrost/REDACTION/releases/latest)
-* Reduced Hurt Animation - [Polyfrost's BetterHurtCam](https://github.com/Polyfrost/BetterHurtCam/releases/latest)
+* Reduced Hurt Animation - [Polyfrost's BetterHurtCam](https://github.com/Scherso/BetterHurtCam/releases/latest)
 
 ### Other Mods
 
 * Toggle Sneak/Sprint - [Lily's SimpleToggleSprint](https://github.com/My-Name-Is-Jeff/SimpleToggleSprint/releases/latest)
 * Nick Hider - [Sk1er's NickHider](https://sk1er.llc/mods/nick_hider)
 * WorldEdit CUI - [Mumfrey's WorldEditCUI](https://www.curseforge.com/minecraft/mc-mods/worldeditcui/files/all?filter-game-version=2020709689%3A5806)
-* Replay Mod - [CrushedPixel & johni0702's Replay Mod](https://www.replaymod.com/download/download_new.php?version=1.8.9-2.5.2)
+* Replay Mod - [CrushedPixel & johni0702's Replay Mod](https://modrinth.com/mod/replaymod/versions)
 * Screenshot Uploader - [Sk1er's Patcher](https://sk1er.club/mods/patcher)
 * Auto Text Hot Key **(BANNABLE ON HYPIXEL)** - [MattsOnMC's MacroKey Keybinding](https://www.curseforge.com/minecraft/mc-mods/macrokey-keybinding/files/all?filter-game-version=2020709689%3A5806)
 * Mumble Link - [snipingcoward's Mumble Link](https://www.curseforge.com/minecraft/mc-mods/mumblelink/files/all?filter-game-version=2020709689%3A5806)

--- a/docs/latest/feather_client.md
+++ b/docs/latest/feather_client.md
@@ -124,7 +124,7 @@ mod authors and it is advised against supporting them.
 
 ## External Mods
 
-* [Replay Mod](https://www.replaymod.com)
+* [Replay Mod](https://modrinth.com/mod/replaymod/versions)
 * [OptiFine](https://optifine.net)
 * [Xaero's Minimap](https://www.curseforge.com/minecraft/mc-mods/xaeros-minimap)
 * [MumbleLink](https://www.curseforge.com/minecraft/mc-mods/mumblelink)

--- a/docs/latest/lunar_client.md
+++ b/docs/latest/lunar_client.md
@@ -90,7 +90,7 @@ checking out
 * Toggle Sneak/Sprint - Vanilla (Accessible in Controls and Accessibility Settings menus)
 * Nick Hider - None
 * WorldEdit CUI - None
-* Replay Mod - [CrushedPixel & johni0702's Replay Mod](https://www.replaymod.com/download)
+* Replay Mod - [CrushedPixel & johni0702's Replay Mod](https://modrinth.com/mod/replaymod/versions)
 * Screenshot Uploader - [isXander's Shotify](https://modrinth.com/mod/shotify)
 * Auto Text Hot Key **(BANNABLE ON HYPIXEL)** - [GGCrosby's Simple Macros](https://www.curseforge.com/minecraft/mc-mods/fabric-simple-macros)
 * Mumble Link - None


### PR DESCRIPTION
- The [old BetterHurtCam link](https://github.com/Polyfrost/BetterHurtCam/releases/latest) led to a 404 page. The new link that I have added leads to a working download and looks like the same mod.
- ReplayMod was uploaded to modrinth a month ago and modrinth is a better source of getting the mod rather than leading to the main website page or a direct download to an old mod version.