### PR TITLE
fix: resolve Danker's Skyblock Mod leading to an empty page

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -47,7 +47,6 @@ nav:
   - "1.8.9":
       - "Mods":
           - "5zig": "1.8.9/5zig.md"
-          - "Danker's Skyblock Mod": "1.8.9/dsm.md"
           - "Dungeon Utilities": "1.8.9/dungeon_utilities.md"
           - "HyChat": "1.8.9/hychat.md"
           - "Skyblock Reinvented": "1.8.9/skyblock_reinvented.md"


### PR DESCRIPTION
it got removed, but the link to the page is still present