### PR TITLE
[Merged] [Lunar] change from kad7 stats to bedwars mod, remove old cooldowns mod

### DIFF
--- a/docs/1.8.9/lunar_client.md
+++ b/docs/1.8.9/lunar_client.md
@@ -56,7 +56,7 @@ I do not have Lunar Client and don't intend on downloading it. If you know where
 
 #### Bedwars
 
-* Stats - [KAD7's HyStats](https://cdn.discordapp.com/attachments/1009757412921708604/1134269972877676574/HyStats-v4.0_1.8.9.jar)
+* Stats - [Error404's Bedwars Mod](https://modrinth.com/mod/bedwars-mod)
 * Height Limit - [Polyfrost's EvergreenHUD](https://modrinth.com/mod/evergreenhud)
 * Resource Counter - [Polyfrost's EvergreenHUD](https://modrinth.com/mod/evergreenhud)
 * Colored Beds - [Polyfrost's Hytils Reborn](https://modrinth.com/mod/hytils)
@@ -114,7 +114,7 @@ For a list of Skyblock mods please see my other list [here](https://alternatives
 * Shiny Pots - [Polyfrost's GlintColorizer](https://modrinth.com/mod/glintcolorizer)
 * Scrollable Tooltips - [Sk1er's Scrollable Tooltips](https://www.sk1er.club/mods/text_overflow_scroll)
 * Particle Mod - [Polyfrost's OverflowParticles](https://modrinth.com/mod/overflowparticles)
-* Cooldowns - [Canalex's Cooldowns](https://cdn.discordapp.com/attachments/778792141932986401/1207183981720637510/Cooldowns_-_1.8.9.jar)
+* Cooldowns - ?
 * Time Changer - [Polyfrost's PolyTime](https://modrinth.com/mod/polytime)
 * Block Outline - [Aycy's BlockOverlay](https://github.com/SkyblockClient/SkyblockClient-REPO/raw/refs/heads/main/files/mods/Block_Overlay_4.0.3.jar)
 * Item Physics - [CreativeMD's ItemPhysic Lite](https://www.curseforge.com/minecraft/mc-mods/itemphysic-lite/files?version=1.8.9)


### PR DESCRIPTION
Changed bedwars stats to Error404's bedwars mod since hystats has been discontinued

also removed exsisting discord links as that way of hosting has been removed, all discord download links have expirey