### PR TITLE
Start work on Skytils page for latest

### DIFF
--- a/docs/latest/home.md
+++ b/docs/latest/home.md
@@ -20,3 +20,4 @@ Click the links below or use the sidebar navigation to find the list you want.
 * [Essential](https://alternatives.microcontrollers.dev/latest/essential)
 * [OptiFine](https://alternatives.microcontrollers.dev/latest/optifine)
 * [Patcher](https://alternatives.microcontrollers.dev/latest/patcher)
+* [Skytils](https://alternatives.microcontrollers.dev/latest/skytils)

--- a/docs/latest/skytils.md
+++ b/docs/latest/skytils.md
@@ -1,0 +1,150 @@
+# Skytils Alternatives
+
+Skytils is a Hypixel Skyblock mod available on both 1.8.9 and 1.21. In the
+1.21 version, it continues its practice of bundling Essential, which gives the user
+no ability to remove it, despite both the issues with Essential and the fact that it is fully unnecessary.
+
+For more information on exactly why Essential is bad and it is considered such a party foul to bundle it, check out the [Essential Alternatives Page](https://alternatives.microcontrollers.dev/latest/essential/).
+
+*this page is still a work in progress*
+
+## General
+
+* Custom Armor Color - [Skyblocker](https://modrinth.com/mod/skyblocker-liap)
+* Command Aliases - [Skyblocker](https://modrinth.com/mod/skyblocker-liap)
+* Griffin Burrow Locator and Waypoints - [SkyHanni](https://modrinth.com/mod/SkyHanni)?
+* Mythological Event Drops Tracker - ?
+* Track Gaia Construct Hits - ?
+* Reparty Command - ?
+* Auto Accept Reparty - [Skyblocker](https://modrinth.com/mod/skyblocker-liap)
+* Custom Key Shortcuts - [Command Keys](https://modrinth.com/mod/commandkeys)
+* Better Auction House Price Input - ?
+* Copy Deaths to Clipboard ?
+* Spam Hider, including custom spam hiders - [Skyblocker](https://modrinth.com/mod/skyblocker-liap)
+* Custom Enchant Names - ?
+* Moveable Item Highlight - ?
+* Moveable Action Bar - ?
+
+## Dungeons
+
+* Blaze Solver - [Skyblocker](https://modrinth.com/mod/skyblocker-liap)
+* Boulder Puzzle Solver - [Skyblocker](https://modrinth.com/mod/skyblocker-liap)
+* Simon Says Solver - [Skyblocker](https://modrinth.com/mod/skyblocker-liap)
+* Trivia Solver - [Skyblocker](https://modrinth.com/mod/skyblocker-liap)
+* Three Weirdo Solver - [Skyblocker](https://modrinth.com/mod/skyblocker-liap)
+* Spirit Leap Names - [Skyblocker](https://modrinth.com/mod/skyblocker-liap)?
+* Click in Order Terminal Solver - [Skyblocker](https://modrinth.com/mod/skyblocker-liap)
+* Ice Path Solver - [Skyblocker](https://modrinth.com/mod/skyblocker-liap)
+* Creeper Beams Solver - [Skyblocker](https://modrinth.com/mod/skyblocker-liap)
+* Target Shooting Solver - ?
+* Alignment Device Solver - ?
+* Tic Tac Toe Solver - [Skyblocker](https://modrinth.com/mod/skyblocker-liap)
+* Select Color Solver - [Skyblocker](https://modrinth.com/mod/skyblocker-liap)
+* Stop Dropping, Salvaging, and Selling Starred Dungeon Items - ?
+* Bigger Bat Rendering and Bat Hitbox Display - ?
+* Giant, Sadan, and Necron HP Display - ?
+* Better Sadan Interest Timer - ?
+* Score Calculation - [Skyblocker](https://modrinth.com/mod/skyblocker-liap)
+* Dungeon Timer - ?
+* Necron Phase Timer - ?
+* Dungeon reroll Confirmation - ?
+* Skeleton Master Boxes - ?
+* Correct Livid Finder - ?
+* Dungeon Chest Profit - [Skyblocker](https://modrinth.com/mod/skyblocker-liap)
+* Dungeon Map - [Skyblocker](https://modrinth.com/mod/skyblocker-liap)
+* Guardian Respawn Timer - ?
+* Boxed Tanks and Protected Teammates - ?
+* Tank Range Display Circle - ?
+* Auto Reparty on Dungeon End - ?
+* Death Counter - ?
+* Giant HP at feet - ?
+* Sadan Phase Timers - ?
+* Spirit Leap Highlights for Names and Classes - [Skyblocker](https://modrinth.com/mod/skyblocker-liap)?
+* Big Crypts Counter - ?
+* Highlight Spirit Bow - ?
+
+## Farming
+
+* Hungry Hiker Solver - [Skyblocker](https://modrinth.com/mod/skyblocker-liap)
+* Treasure Hunter Solver - [Skyblocker](https://modrinth.com/mod/skyblocker-liap)
+
+## Mining
+
+* Fetchur Solver - [Skyblocker](https://modrinth.com/mod/skyblocker-liap) / [SkyblockTweaks](https://modrinth.com/mod/sbt)
+* Puzzler Solver - [Skyblocker](https://modrinth.com/mod/skyblocker-liap) / [SkyOcean](https://modrinth.com/mod/skyocean)
+* Raffle Waypoint and Warning - ?
+* Show hidden sneaky creepers - ?
+* Dark Mode Mist - ?
+* More Visible Ghosts - ?
+* Recolor Carpets - [Skyblocker](https://modrinth.com/mod/skyblocker-liap)
+* Highlight Completed Commissions *  [SkyOcean](https://modrinth.com/mod/skyocean) / [SkyblockTweaks](https://modrinth.com/mod/sbt)
+* Crystal Hollows Map *  [Skyblocker](https://modrinth.com/mod/skyblocker-liap)
+* Crystal Hollows Waypoints - [Skyblocker](https://modrinth.com/mod/skyblocker-liap)
+
+## Items
+
+* Pet Item Confirmation - ?
+* Highlight Active & Favorite Pets - ?
+* Hide Implosion Particles - ?
+* Hide Midas Staff Gold Blocks - ?
+* Big Item Drops - ?
+* Larger Heads - ?
+* Show Enchanted Book, Potion, Minion Tiers, and Dungeon Stars - [Skyblocker](https://modrinth.com/mod/skyblocker-liap)?
+* Show Pet Candies - ?
+* Only Collect Enchanted Items - ?
+* Dungeon Potion Lock - ?
+* Power Orb Lock - ?
+* Prevent Placing Spirit Sceptre and Flower of Truth - ?
+* Transparent Head Layer - [Skyblocker](https://modrinth.com/mod/skyblocker-liap)
+* Show NPC Sell Values - [Skyblocker](https://modrinth.com/mod/skyblocker-liap)
+* Show Price of Items in the Experimentation Table - ?
+* Jerry-chine Gun Sound Hider - ?
+* Show Enchanted Book Abbreviation - ?
+* Show Radioactive Bonus - ?
+* Etherwarp Teleport Display - [Skyblocker](https://modrinth.com/mod/skyblocker-liap)
+*
+
+## Slayers
+
+* Show Slayer RNG Progress as the Boss Bar - ?
+* Soulflow Display - ?
+* Low Soulfow Ping - ?
+* Slayer Display - [Skyblocker](https://modrinth.com/mod/skyblocker-liap)
+* Yang Glyph Ping and Highlight - [Skyblocker](https://modrinth.com/mod/skyblocker-liap)
+* Nukekebi Skull Highlight - [Skyblocker](https://modrinth.com/mod/skyblocker-liap)
+* Seraph Display - ?
+* Broken Heart Radiation Hider for Others' Bosses - ?
+* Slayer Time to Kill - ?
+* Re-color seraph boss - ?
+
+## Miscellaneous
+
+* Hide Witherborn Boss Bars - ?
+* Hide Fire and Lightning - ?
+* Custom Damage Splash - ?
+* Legion and Dolphin player displays - ?
+* Alerts for Hidden Jerry spawns - ?
+* Relic and Rare Uber Relic waypoints - [Skyblocker](https://modrinth.com/mod/skyblocker-liap)?
+* Stop other mods from cancelling terminal clicks - ?
+* Slayer miniboss spawn alert - ?
+* Hide fishing hooks from other players - ?
+* Placed Summoning Eye Display - ?
+* Spider's Den Rain Timer - ?
+* Stop Dropping Valuable Items (customizable BIN value) - ?
+* Trapper cooldown alarm - ?
+* Click anywhere to accept Trapper Task - ?
+* Rare drop sounds for mythological event drops - ?
+* Highlight disabled potion effects in cookie menu - [SkyblockTweaks](https://modrinth.com/mod/sbt)
+* Hidden Jerry Timer - ?
+* Hidden Jerry & Jerry Box Tracker - ?
+* Jerry Perk Display - ?
+* Remove Left Over Bleeds from Minotaurs - ?
+* Hide Dying Mobs - ?
+* Cooldown Tracker - ?
+* /g leave confirmation - ?
+* Prehistoric Egg Blocks Walked - ?
+* Auto Copy Rare Drops - ?
+
+# Contributors
+
+* [MisterCheezeCake](https://github.com/MisterCheezeCake)


### PR DESCRIPTION
This adds the barebones of a Skytils page on latest. It has a list of most features (at least the ones in the ReadMe), and containers alternatives for some of them. The page is far from complete, there are probably many features with a ? next to them for which alternatives do exist, but I wasn't able to find them in my extremely cursory starting search.